### PR TITLE
Update moment to 2.19.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-dot-reporter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3046,9 +3046,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/pierreroth64/jest-dot-reporter#readme",
   "dependencies": {
     "chalk": "2.1.0",
-    "moment": "2.18.1",
+    "moment": "2.19.3",
     "progress": "2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently adding `jest-dot-reporter` to a project will cause GitHub to show a security vuln message related to `moment@2.18.1`. The recommendation in [the CVE](https://nvd.nist.gov/vuln/detail/CVE-2017-18214) is to upgrade to `2.19.3`.

I like this reporter (it's super simple!), so I figured I'd contribute this quick change.