### PR TITLE
Add obsolete snapshot error message

### DIFF
--- a/lib/jest-dot-reporter.js
+++ b/lib/jest-dot-reporter.js
@@ -57,6 +57,9 @@ class JestDotReporter {
       }
     });
     console.log(infoFmt(`Ran ${numTotalTests} tests in ${testDuration()}`));
+    if (snapshot.failure) {
+      console.log('\n' + failedFmt(`Obsolete snapshot(s)`) + ' found, run with `npm test -- -u` to remove them. \n');
+    }
     if (numPassedTests) {
       console.log(this._getStatus('passed') + passedFmt(` ${numPassedTests} passing`));
     }


### PR DESCRIPTION
Jest Dot Reporter doesn't show any error message if obsolete snapshots are found. It shows all tests passing, whilst npm throws an error saying the tests failed. 

The aim of this PR is to add an error message when there are obsolete snapshots, e.g. when someone deletes a test but forgets to remove the snapshot too.

Before:
![screen shot 2018-07-24 at 10 30 18](https://user-images.githubusercontent.com/21029500/43129945-6a975d0e-8f2d-11e8-85e2-8723caf76c53.png)

After:
![screen shot 2018-07-24 at 10 29 42](https://user-images.githubusercontent.com/21029500/43129940-66c13b8c-8f2d-11e8-995f-433117bf1b58.png)
